### PR TITLE
Propagated M_HART_ID for parameterization

### DIFF
--- a/rtl/csr.sv
+++ b/rtl/csr.sv
@@ -11,7 +11,8 @@ module csr
   import nox_utils_pkg::*;
 #(
   parameter int SUPPORT_DEBUG = 1,
-  parameter int MTVEC_DEFAULT_VAL = 'h1000 // 4KB
+  parameter int MTVEC_DEFAULT_VAL = 'h1000, // 4KB
+  parameter int unsigned M_HART_ID = `M_HART_ID
 )(
   input                     clk,
   input                     rst,
@@ -178,7 +179,7 @@ module csr
       //RV_CSR_MVENDORID: csr_rd_o = `M_VENDOR_ID;
       //RV_CSR_MARCHID:   csr_rd_o = `M_ARCH_ID;
       //RV_CSR_MIMPLID:   csr_rd_o = `M_IMPL_ID;
-      RV_CSR_MHARTID:   csr_rd_o = `M_HART_ID;
+      RV_CSR_MHARTID:   csr_rd_o = M_HART_ID;
       default:          csr_rd_o = rdata_t'('0);
     endcase
 

--- a/rtl/execute.sv
+++ b/rtl/execute.sv
@@ -11,7 +11,8 @@ module execute
   import nox_utils_pkg::*;
 #(
   parameter int SUPPORT_DEBUG     = 1,
-  parameter int MTVEC_DEFAULT_VAL = 'h1000 // 4KB
+  parameter int MTVEC_DEFAULT_VAL = 'h1000, // 4KB
+  parameter int unsigned M_HART_ID = `M_HART_ID
 )(
   input                     clk,
   input                     rst,
@@ -229,7 +230,8 @@ module execute
 
   csr #(
     .SUPPORT_DEBUG      (SUPPORT_DEBUG),
-    .MTVEC_DEFAULT_VAL  (MTVEC_DEFAULT_VAL)
+    .MTVEC_DEFAULT_VAL  (MTVEC_DEFAULT_VAL),
+    .M_HART_ID          (M_HART_ID)
   ) u_csr (
     .clk                (clk),
     .rst                (rst),

--- a/rtl/nox.sv
+++ b/rtl/nox.sv
@@ -16,7 +16,8 @@ module nox
   parameter int TRAP_ON_MIS_LSU_ADDR  = 1,      // Trap in case of misaligned addr on LSU
   parameter int TRAP_ON_LSU_ERROR     = 1,      // Trap in case of LSU error
   parameter int FETCH_IF_ID           = 0,
-  parameter int LSU_IF_ID             = 1
+  parameter int LSU_IF_ID             = 1,
+  parameter int unsigned M_HART_ID = `M_HART_ID
 )(
   input                 clk,
   input                 arst,
@@ -173,7 +174,8 @@ module nox
 
   execute #(
     .SUPPORT_DEBUG         (SUPPORT_DEBUG),
-    .MTVEC_DEFAULT_VAL     (MTVEC_DEFAULT_VAL)
+    .MTVEC_DEFAULT_VAL     (MTVEC_DEFAULT_VAL),
+    .M_HART_ID             (M_HART_ID)
   ) u_execute (
     .clk                   (clk),
     .rst                   (rst),


### PR DESCRIPTION
The value for the MHART csr was determined directly from the preprocessor on nox_pkg.svh.

This pull requests changes that to be parameterized,and propagated through the following modules: csr.sv, execute.sv, and nox.sv.

The default value is still determined by the preprocessor, but can be changed for multiple instanciations.